### PR TITLE
Redesign the sync_bounds interface to be non-modifying.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
 version = "0.6.2"
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Miter"
 uuid = "e2c39885-2134-4813-a274-cbd32ca8996e"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "0.6.2"
+version = "0.7.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Miter = "e2c39885-2134-4813-a274-cbd32ca8996e"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,7 +74,9 @@ Plot(Hgrid(), # specified first; renders first
 
 Sync x and y bounds in a tableau.
 
-```julia
+```@example all
+using Accessors # for @modify
+
 function wobbler(x, y, r, rotate)
     Plot(Lines([sincos(θ) .* (r * (sin(θ  * 3 + rotate)/4 + 1))
                 for θ in range(0, 2*π; length = 200)]))
@@ -84,7 +86,7 @@ m = Tableau(balanced_rectangle([wobbler(0, 0, 2, 0),
                                 wobbler(1, 0, 1, π/2),
                                 wobbler(-1, 0, 3, -π/2),
                                 wobbler(1, 3, 1, π)]));
-sync_bounds!(:xy, m)
+@modify(sync_bounds(:xy), m.contents) # sync columns and rows
 ```
 
 Q5 (five quantiles) plots.

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -36,9 +36,6 @@ bounds_xy(a::AbstractArray) = isempty(a) ? (∅, ∅) : mapreduce(bounds_xy, hul
 # bounds for a coordinate pair
 bounds_xy(xy::Tuple) = (Interval(extrema(xy[1])...), Interval(extrema(xy[2])...))
 
-# convenience function to combine bounds
-bounds_xy(items...) = isempty(items) ? (∅, ∅) : mapreduce(bounds_xy, hull_xy, items)
-
 function finalize end
 
 """

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -6,10 +6,12 @@ module Plots
 
 # reexported as API
 export Plot, Tableau, Phantom, Lines, Scatter, Circles, Hline, Hgrid, LineThrough,
-    Annotation, Invisible, sync_bounds!
+    Annotation, Invisible, sync_bounds
 
+using Accessors: @insert
 using ArgCheck: @argcheck
-using DocStringExtensions: SIGNATURES
+import ConstructionBase
+using DocStringExtensions: FUNCTIONNAME, SIGNATURES
 using Unitful: mm
 
 using ..Axis: Linear, DrawingArea, y_coordinate_to_canvas, coordinates_to_point, finalize,
@@ -50,7 +52,7 @@ Base.@kwdef struct PlotStyle
     margin_top::LENGTH = DEFAULTS.plot_style_margin_top
 end
 
-struct Plot <: AbstractVector{Any}
+struct Plot
     contents::Vector{Any}
     x_axis
     y_axis
@@ -69,29 +71,15 @@ struct Plot <: AbstractVector{Any}
     end
 end
 
+function ConstructionBase.constructorof(::Type{Plot})
+    (contents, x_axis, y_axis, style) -> Plot(contents; x_axis, y_axis, style)
+end
+
 Plot(contents...; kwargs...) = Plot(collect(Any, contents); kwargs...)
 
+bounds_xy(plot::Plot) = bounds_xy(plot.contents)
+
 @declare_showable Plot
-
-###
-### vector and dequeue API
-###
-
-Base.size(plot::Plot) = size(plot.contents)
-
-Base.getindex(plot::Plot, i::Integer) = Base.getindex(plot.contents, i)
-
-Base.setindex!(plot::Plot, value, i::Integer) = Base.setindex(plot.contents, value, i)
-
-Base.push!(plot::Plot, items...) = push!(plot.contents, items...)
-
-Base.pushfirst!(plot::Plot, items...) = pushfirst!(plot.contents, items...)
-
-Base.append!(plot::Plot, collections...) = pushfirst!(plot.contents, collections...)
-
-Base.pop!(plot::Plot) = pop!(plot.contents)
-
-Base.insert!(plot::Plot, i::Integer, item) = insert!(plot.contents, i, item)
 
 ###
 ### rendering and bounds
@@ -123,7 +111,7 @@ end
 #### Tableau
 ####
 
-struct Tableau <: AbstractMatrix{Any}
+struct Tableau
     contents::Matrix{Any}
     horizontal_divisions
     vertical_divisions
@@ -145,15 +133,14 @@ struct Tableau <: AbstractMatrix{Any}
     end
 end
 
+function ConstructionBase.constructorof(::Type{Tableau})
+    (contents, horizontal_divisions, vertical_divisions) ->
+        Tableau(contents; horizontal_divisions, vertical_divisions)
+end
+
 @declare_showable Tableau
 
 Tableau(contents::AbstractVector; kwargs...) = Tableau(reshape(contents, 1, :); kwargs...)
-
-Base.size(tableau::Tableau) = size(tableau.contents)
-
-Base.getindex(tableau::Tableau, i::Vararg{Int}) = getindex(tableau.contents, i...)
-
-Base.setindex!(tableau::Tableau, item, i::Vararg{Int}) = setindex(tableau.contents, item, i...)
 
 function PGF.render(sink::PGF.Sink, rectangle::PGF.Rectangle, tableau::Tableau)
     (; contents, horizontal_divisions, vertical_divisions) =  tableau
@@ -556,63 +543,87 @@ PGF.render(sink::PGF.Sink, drawing_area::DrawingArea, ::Invisible) = nothing
 """
 $(SIGNATURES)
 
-Add an `Invisible(xy)` to each plot in `itr`.
+Add an `Invisible(xy)` to each plot in `itr`. Internal helper function.
 """
-function _add_invisible!(xy::Tuple{CoordinateBounds,CoordinateBounds}, itr)
+function _add_invisible(xy::Tuple{CoordinateBounds,CoordinateBounds}, itr)
     invisible = Invisible(xy)
-    for i in itr
-        push!(i, invisible)
-    end
-    itr
+    map(x -> @insert(last(x.contents) = invisible), itr)
 end
 
 """
 $(SIGNATURES)
 
-Make sure that axis bounds are the same for axes `:x`, `:y`, or both (`:xy`), as determined
-by `tag`. Tag can be given in the form of `Val(tag)` too, this is a convenience wrapper.
+Make sure that axis bounds are the same for axes as determined
+by `tag` (see below).
 
-Matrices (like [`Tableau`](@ref) are synced by column- and row, according to the `tag`.
+Tag can be given in the form of `Val(tag)` too, this is a convenience wrapper.
 
-Vectors are just synced as specified.
+Possible tags:
 
-All methods return the (modified) second argument.
+- `:X`, `:Y`, `:XY`: make the specified axes in *all* items of the collection the same
+
+- `:x`, `:y`, `:xy`: make x/y axes the same in plots that are in the same column/row, only works for
+
+`:x`, `:y`, and `:xy` only work for matrix-like arguments.
+
+All methods return the (modified) first argument.
+
+# Explanation
+
+To illustrate the lowercase tags, consider the arrangement
+
+```ascii
+y/vertical axis
+│
+│ C  D
+│ A  B
+└────────x/horizontal axis
+```
+which could be entered as eg
+```julia
+t = Tableau([A C; B D])
+```
+Then `$(FUNCTIONNAME)(:x, t)` would ensure that A and C have the same bounds for the
+x-axis, and similarly B and D.
 """
-@inline function sync_bounds!(tag::Symbol, collection)
-    @argcheck tag ∈ (:x, :y, :xy)
-    sync_bounds!(Val(tag), collection)
+@inline function sync_bounds(tag::Symbol, collection)
+    @argcheck tag ∈ (:x, :y, :xy, :X, :Y, :XY)
+    sync_bounds(Val(tag), collection)
 end
 
-function sync_bounds!(::Val{:x}, v::AbstractVector)
-    xb, _ = bounds_xy(v)
-    _add_invisible!((xb, ∅), v)
+sync_bounds(tag::Val) = Base.Fix1(sync_bounds, tag)
+
+@inline sync_bounds(tag::Symbol) = sync_bounds(Val(tag))
+
+function sync_bounds(tag::Val{:X}, collection)
+    # vectors are treated like 1×N matrices, x axes are synced
+    xb, _ = bounds_xy(collection)
+    _add_invisible((xb, ∅), collection)
 end
 
-function sync_bounds!(::Val{:y}, v::AbstractVector)
-    _, yb = bounds_xy(v)
-    _add_invisible!((∅, yb), v)
+function sync_bounds(tag::Val{:Y}, collection)
+    _, yb = bounds_xy(collection)
+    _add_invisible((∅, yb), collection)
 end
 
-sync_bounds!(::Val{:xy}, v::AbstractVector) = _add_invisible!(bounds_xy(v), v)
+sync_bounds(tag::Val{:XY}, collection) = _add_invisible(bounds_xy(collection), collection)
 
-function sync_bounds!(::Val{:x}, m::AbstractMatrix)
-    for row in eachrow(m)
-        sync_bounds!(Val(:x), row)
+function sync_bounds(tag::Union{Val{:x},Val{:y},Val{:xy}}, collection::T) where T
+    if Base.IteratorSize(T) == Base.HasShape{2}()
+        sync_bounds(tag, collect(collection))
+    else
+        throw(ArgumentError("Tag $(tag) only works for matrix-like arguments."))
     end
-    m
 end
 
-function sync_bounds!(::Val{:y}, m::AbstractMatrix)
-    for col in eachcol(m)
-        sync_bounds!(Val(:y), col)
-    end
-    m
+function sync_bounds(::Val{:x}, m::AbstractMatrix)
+    mapreduce(row -> permutedims(sync_bounds(Val(:X), row)), vcat, eachrow(m))
 end
 
-function sync_bounds!(::Val{:xy}, m::AbstractMatrix)
-    sync_bounds!(Val(:x), m)
-    sync_bounds!(Val(:y), m)
-    m
+function sync_bounds(::Val{:y}, m::AbstractMatrix)
+    mapreduce(col -> sync_bounds(Val(:Y), col), hcat, eachcol(m))
 end
+
+sync_bounds(::Val{:xy}, m::AbstractMatrix) = sync_bounds(Val(:x), sync_bounds(Val(:y), m))
 
 end

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -262,7 +262,7 @@ struct Circles
     @doc """
     $(SIGNATURES)
 
-    Taking an iterator or vector aof `(x, y, w)` triplets (eg `NTuple{3}`, but anything
+    Taking an iterator or vector of `(x, y, w)` triplets (eg `NTuple{3}`, but anything
     iterable with 3 elements will do), draw circles centered on `(x, y)` coordinates
     with radius `scale * √w`.
 


### PR DESCRIPTION
- remove the old modifying API sync_bounds!
- add a currying version
- make Tableau and Plots work with Accessors etc
- remove AbstractVector and AsbtractMatrix API from the above
- clean up minor API inconsistencies
- fix example in docs