### PR TITLE
Informative error messages on compilation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Miter"
 uuid = "e2c39885-2134-4813-a274-cbd32ca8996e"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,10 @@ is_png(path) = open(io -> read(io, 4), path, "r") == b"\x89PNG"
     @test is_pdf(pdf_path)
 end
 
+@testset "compile error" begin
+    p = Plot(Lines((x,x) for x in 1:3); title = Miter.LaTeX(raw"$unfinished"; skip_check = true))
+    @test_throws raw"Extra }, or forgotten $" Miter.save(tempname() * ".pdf", p)
+end
 
 ####
 #### pgf


### PR DESCRIPTION
Show the LaTeX error message when compilation fails.

[Capture solution](https://discourse.julialang.org/t/capture-stdout-and-stderr-in-case-a-command-fails/101772/3?u=tamas_papp) suggested by @carstenbauer, thanks!