### PR TITLE
refactor matrix balancing and Tableau, new semantics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Miter"
 uuid = "e2c39885-2134-4813-a274-cbd32ca8996e"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "0.11.1"
+version = "0.12.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -116,7 +116,7 @@ function wobbler(x, y, r, rotate)
                 for θ in range(0, 2*π; length = 200)]))
 end
 
-m = Tableau(balanced_rectangle([wobbler(0, 0, 2, 0),
+m = Tableau(balanced_matrix([wobbler(0, 0, 2, 0),
                                 wobbler(1, 0, 1, π/2),
                                 wobbler(-1, 0, 3, -π/2),
                                 wobbler(1, 3, 1, π)]));
@@ -161,7 +161,7 @@ Plot(hpd_heatmap(h, range(0.2, 0.8; step = 0.2), ColorSchemes.OrRd_5))
 ### Tableaus
 
 ```@example all
-Tableau(balanced_rectangle(
+Tableau(balanced_matrix(
         [Plot(Lines([(x, exp(-0.5 * abs2(x)) / √(2π))
                      for x in range(-2, 2; length = 101)]);
               y_axis = Axis.Linear(; label = "pdf of normal distribution")),

--- a/src/pgf.jl
+++ b/src/pgf.jl
@@ -479,6 +479,19 @@ function split_interval(a::LENGTH, b::LENGTH, divisions)
     accumulate(((a, b), d) -> (b, b + _resolve2(d)), divisions; init = (a, a))
 end
 
+"""
+$(SIGNATURES)
+
+Split `rectangle` along `x_divisions` and `y_divisions`. Return the result as a
+`Matrix`, or `SMatrix` when both divisions are specified as `Tuple`s.
+
+Note: the matrix is indexed with *horizontal* and *vertical* coordinates (in this
+order), and indexing conventions follow the Cartesian coordinate system. If you want the
+arrangement of how matrices are usually displayed, use
+```julia
+reverse(permutedims(split_matrix(...)); dims = 1)
+```
+"""
 function split_matrix(rectangle::Rectangle,
                       x_divisions::Union{NTuple{N,Any},AbstractVector},
                       y_divisions::Union{NTuple{M,Any},AbstractVector}) where {N,M}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,14 +174,17 @@ end
         @test is_svg(filename)
     end
 
-    tableau = Tableau(balanced_rectangle(Plot(e) for e in [L, S, C, HX, HY, H2]))
+    tableau = Tableau(balanced_matrix(Plot(e) for e in [L, S, C, HX, HY, H2]))
     filename = tempname() * ".pdf"
     Miter.save(filename, tableau)
     @test is_pdf(filename)
 end
 
 @testset "balanced rectangle" begin
-    @test @inferred(balanced_rectangle(1:3)) == [3 1; nothing 2]
+    @test @inferred(balanced_matrix(1:3)) == [1 2; 3 nothing]
+    @test balanced_matrix(1:3; width_bias = 0.0001) == reshape(1:3, :, 1)
+    @test balanced_matrix(1:3; width = 1) == reshape(1:3, :, 1)
+    @test balanced_matrix(1:3; height = 1) == reshape(1:3, 1, :)
 end
 
 @testset "sync bounds" begin


### PR DESCRIPTION
`Tableau` follows the visual arrangement that is used to print matrices.

`balanced_matrix` replaces `balanced_rectangle`, minor bug fixes, explicit specification of width and heigth.